### PR TITLE
Move dependencies to requirements.txt, add Fasttext to list of dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Utrecht predict
 
-Install Flask with:
+Install the dependencies with:
 
 ```bash
-pip3 install Flask
+pip3 install -r requirements.txt
 ```
 
 Then run the application with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask==2.0.2
+fasttext==0.9.2


### PR DESCRIPTION
Currently Fasttext is missing from the dependencies list.